### PR TITLE
Fix game object display bug

### DIFF
--- a/app.js
+++ b/app.js
@@ -571,6 +571,28 @@
     const ctx = canvas.getContext('2d');
 
     // Live video only (no canvas drawing until capture)
+    const drawLiveBoxes = (preds) => {
+      overlay.classList.remove('interactive');
+      overlay.innerHTML = '';
+      const vwRect = vw.getBoundingClientRect();
+      const scaleX = vwRect.width && video.videoWidth ? vwRect.width / video.videoWidth : 1;
+      const scaleY = vwRect.height && video.videoHeight ? vwRect.height / video.videoHeight : 1;
+      const list = (preds || []).filter(p => p.score > MIN_SCORE);
+      list.forEach((p) => {
+        const [x, y, w, h] = p.bbox;
+        const b = document.createElement('div');
+        b.className = 'box';
+        b.style.left = `${x * scaleX}px`;
+        b.style.top = `${y * scaleY}px`;
+        b.style.width = `${w * scaleX}px`;
+        b.style.height = `${h * scaleY}px`;
+        const lab = document.createElement('label');
+        lab.textContent = `${(p.class || '').toUpperCase()} ${(p.score*100).toFixed(0)}%`;
+        translateLabelToSv(p.class).then(sv => { lab.textContent = `${(sv || '').toUpperCase()} ${(p.score*100).toFixed(0)}%`; }).catch(() => {});
+        b.appendChild(lab);
+        overlay.appendChild(b);
+      });
+    };
 
     startCamera(video).then(loadModel).then(() => {
       resetTimer();
@@ -578,6 +600,22 @@
         stopCamera();
         finishRound(false);
       });
+      // Throttled live detection overlay during play
+      stopLiveDetect();
+      liveDetectInterval = setInterval(async () => {
+        if (liveDetectInProgress) return;
+        if (!detectorModel) return;
+        if (video.readyState < 2) return;
+        try {
+          liveDetectInProgress = true;
+          const preds = await detectorModel.detect(video);
+          drawLiveBoxes(preds || []);
+        } catch (e) {
+          // ignore transient detection errors
+        } finally {
+          liveDetectInProgress = false;
+        }
+      }, 600);
     }).catch(err => {
       console.error(err);
       alert('Kunde inte starta kamera. Ge kameratillstånd och försök igen.');


### PR DESCRIPTION
Add live detection overlays to the challenger screen to show identified objects during the hunt.

Previously, the `renderPlay` phase did not display any live detection results, making it difficult for the challenger to identify the target object before taking a photo.

---
<a href="https://cursor.com/background-agent?bcId=bc-ea712e3a-362e-408f-9dfe-8191242d4978"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ea712e3a-362e-408f-9dfe-8191242d4978"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

