### PR TITLE
feat: rename to Hitta! and add real-time Firebase multiplayer

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -1,0 +1,10 @@
+{
+  "rules": {
+    "games": {
+      "$gameId": {
+        ".read": true,
+        ".write": true
+      }
+    }
+  }
+}

--- a/firebase.json
+++ b/firebase.json
@@ -6,5 +6,8 @@
       "**/.*",
       "**/node_modules/**"
     ]
+  },
+  "database": {
+    "rules": "database.rules.json"
   }
 }

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-  <title>itta! – Objektduellen</title>
+  <title>Hitta! – Objektduellen</title>
   <link rel="preconnect" href="https://cdn.jsdelivr.net">
   <link rel="preconnect" href="https://unpkg.com">
   <link rel="stylesheet" href="./styles.css">
@@ -14,7 +14,7 @@
 <body>
   <main id="app" class="container">
     <header class="topbar">
-      <div class="brand">itta!</div>
+      <div class="brand">Hitta!</div>
       <div class="score" id="scoreBar"></div>
     </header>
 

--- a/src/firebase-config.js
+++ b/src/firebase-config.js
@@ -4,10 +4,7 @@
 export const FIREBASE_CONFIG = {
   apiKey: 'YOUR_API_KEY',
   authDomain: 'hitta-3f1fb.firebaseapp.com',
-  // Realtime Database URL — find it in Firebase Console → Realtime Database
-  // US region example:     https://hitta-3f1fb-default-rtdb.firebaseio.com
-  // Europe region example: https://hitta-3f1fb-default-rtdb.europe-west1.firebasedatabase.app
-  databaseURL: 'YOUR_DATABASE_URL',
+  databaseURL: 'https://hitta-3f1fb-default-rtdb.firebaseio.com',
   projectId: 'hitta-3f1fb',
   storageBucket: 'hitta-3f1fb.appspot.com',
   messagingSenderId: 'YOUR_SENDER_ID',

--- a/src/firebase-config.js
+++ b/src/firebase-config.js
@@ -2,11 +2,12 @@
 // Get these values from:
 //   Firebase Console → Project Settings → Your apps → Web app → SDK setup and configuration
 export const FIREBASE_CONFIG = {
-  apiKey: 'YOUR_API_KEY',
+  apiKey: 'AIzaSyCGnODiqNZWsBRST1kqSHr5EWbMVqbhxR0',
   authDomain: 'hitta-3f1fb.firebaseapp.com',
   databaseURL: 'https://hitta-3f1fb-default-rtdb.firebaseio.com',
   projectId: 'hitta-3f1fb',
-  storageBucket: 'hitta-3f1fb.appspot.com',
+  storageBucket: 'hitta-3f1fb.firebasestorage.app',
   messagingSenderId: '566563427329',
-  appId: 'YOUR_APP_ID',
+  appId: '1:566563427329:web:860609ce209b3f35b75c00',
+  measurementId: 'G-0PHESMHMJH',
 };

--- a/src/firebase-config.js
+++ b/src/firebase-config.js
@@ -1,0 +1,15 @@
+// IMPORTANT: Fill in your Firebase project configuration.
+// Get these values from:
+//   Firebase Console → Project Settings → Your apps → Web app → SDK setup and configuration
+export const FIREBASE_CONFIG = {
+  apiKey: 'YOUR_API_KEY',
+  authDomain: 'hitta-3f1fb.firebaseapp.com',
+  // Realtime Database URL — find it in Firebase Console → Realtime Database
+  // US region example:     https://hitta-3f1fb-default-rtdb.firebaseio.com
+  // Europe region example: https://hitta-3f1fb-default-rtdb.europe-west1.firebasedatabase.app
+  databaseURL: 'YOUR_DATABASE_URL',
+  projectId: 'hitta-3f1fb',
+  storageBucket: 'hitta-3f1fb.appspot.com',
+  messagingSenderId: 'YOUR_SENDER_ID',
+  appId: 'YOUR_APP_ID',
+};

--- a/src/firebase-config.js
+++ b/src/firebase-config.js
@@ -7,6 +7,6 @@ export const FIREBASE_CONFIG = {
   databaseURL: 'https://hitta-3f1fb-default-rtdb.firebaseio.com',
   projectId: 'hitta-3f1fb',
   storageBucket: 'hitta-3f1fb.appspot.com',
-  messagingSenderId: 'YOUR_SENDER_ID',
+  messagingSenderId: '566563427329',
   appId: 'YOUR_APP_ID',
 };

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,0 +1,41 @@
+import { initializeApp } from 'https://www.gstatic.com/firebasejs/10.13.2/firebase-app.js';
+import {
+  getDatabase,
+  ref,
+  set,
+  get,
+  update,
+  onValue,
+  off,
+} from 'https://www.gstatic.com/firebasejs/10.13.2/firebase-database.js';
+import { FIREBASE_CONFIG } from './firebase-config.js';
+
+let db;
+
+export function initFirebase() {
+  const app = initializeApp(FIREBASE_CONFIG);
+  db = getDatabase(app);
+}
+
+function gameRef(gameId) {
+  return ref(db, `games/${gameId}`);
+}
+
+export async function createGame(gameId, data) {
+  await set(gameRef(gameId), data);
+}
+
+export async function updateGame(gameId, updates) {
+  await update(gameRef(gameId), updates);
+}
+
+export async function getGame(gameId) {
+  const snap = await get(gameRef(gameId));
+  return snap.val();
+}
+
+export function subscribeGame(gameId, callback) {
+  const r = gameRef(gameId);
+  onValue(r, (snap) => callback(snap.val()));
+  return () => off(r);
+}

--- a/src/router.js
+++ b/src/router.js
@@ -1,5 +1,6 @@
 import { store } from './store.js';
-import { decodeStateFromURL } from './urlState.js';
+import { initFirebase, subscribeGame } from './firebase.js';
+import { getGameIdFromURL } from './urlState.js';
 import { updateScoreBar } from './ui.js';
 import { renderHome } from './screens/home.js';
 import { renderDetect } from './screens/detect.js';
@@ -8,23 +9,102 @@ import { renderPlay } from './screens/play.js';
 import { renderWin } from './screens/win.js';
 import { renderCancel } from './screens/cancel.js';
 
+let firebaseInited = false;
+let currentScreen = null;
+
 export function navigate(screen) {
+  currentScreen = screen;
   switch (screen) {
-    case 'home': renderHome(); break;
+    case 'home':   renderHome();   break;
     case 'detect': renderDetect(); break;
-    case 'wait': renderWait(); break;
-    case 'play': renderPlay(); break;
-    case 'win': renderWin(); break;
+    case 'wait':   renderWait();   break;
+    case 'play':   renderPlay();   break;
+    case 'win':    renderWin();    break;
     case 'cancel': renderCancel(); break;
   }
 }
 
-export function route() {
-  store.game = decodeStateFromURL();
+export function getCurrentScreen() {
+  return currentScreen;
+}
+
+function routeFromGame(game) {
+  if (!game) {
+    if (currentScreen !== 'home') navigate('home');
+    return;
+  }
+
+  // Merge Firebase data into store; keep isActive in sync for legacy helpers
+  store.game = { ...store.game, ...game, isActive: game.status === 'playing' };
   updateScoreBar();
-  if (store.game.canceledBy) { renderCancel(); return; }
-  if (!store.game.isActive) { renderHome(); return; }
-  if (store.game.winner) { renderWin(); return; }
-  if (store.game.targetLabel) { renderPlay(); return; }
-  renderDetect();
+
+  const myRole = store.myRole;
+  let targetScreen;
+
+  switch (game.status) {
+    case 'inviting':
+      targetScreen = myRole === 'A' ? 'wait' : 'home';
+      break;
+    case 'accepted':
+      targetScreen = 'wait';
+      break;
+    case 'playing': {
+      const isChallenger = game.currentTurn === myRole;
+      if (game.targetLabel) {
+        // Target chosen — challenger waits, finder plays
+        targetScreen = isChallenger ? 'wait' : 'play';
+      } else {
+        // No target yet — challenger picks, finder waits
+        targetScreen = isChallenger ? 'detect' : 'wait';
+      }
+      break;
+    }
+    case 'won':
+      targetScreen = 'win';
+      break;
+    case 'canceled':
+      targetScreen = 'cancel';
+      break;
+    default:
+      targetScreen = 'home';
+  }
+
+  if (targetScreen !== currentScreen) {
+    navigate(targetScreen);
+  } else if (targetScreen === 'wait') {
+    // Re-render wait to reflect updated state (e.g. 'inviting' → 'accepted')
+    renderWait();
+  }
+  // detect and play screens are NOT re-rendered mid-screen (camera/timer are active)
+}
+
+export function startSubscription(gameId) {
+  if (store.unsubscribe) {
+    store.unsubscribe();
+    store.unsubscribe = null;
+  }
+  store.unsubscribe = subscribeGame(gameId, routeFromGame);
+}
+
+export function route() {
+  if (!firebaseInited) {
+    initFirebase();
+    firebaseInited = true;
+  }
+
+  const gameId = getGameIdFromURL();
+  if (gameId) {
+    store.gameId = gameId;
+    try {
+      store.myRole = localStorage.getItem(`hitta_role_${gameId}`) || null;
+    } catch {
+      store.myRole = null;
+    }
+    startSubscription(gameId);
+  } else {
+    store.gameId = '';
+    store.myRole = null;
+    if (currentScreen !== 'home') navigate('home');
+    else renderHome();
+  }
 }

--- a/src/screens/cancel.js
+++ b/src/screens/cancel.js
@@ -1,6 +1,6 @@
 import { store } from '../store.js';
 import { navigate } from '../router.js';
-import { encodeStateToURL } from '../urlState.js';
+import { setGameIdInURL } from '../urlState.js';
 import { updateScoreBar, setScreen, screens } from '../ui.js';
 import { DEFAULT_GAME } from '../constants.js';
 
@@ -13,7 +13,7 @@ export function renderCancel() {
   c.className = 'center card';
 
   const msg = document.createElement('h2');
-  msg.textContent = `${store.game.canceledBy || 'Spelare A'} avbröt spelet`;
+  msg.textContent = `${store.game.canceledBy || 'Spelaren'} avbröt spelet`;
 
   const info = document.createElement('div');
   info.className = 'notice';
@@ -23,10 +23,13 @@ export function renderCancel() {
   home.className = 'primary';
   home.textContent = 'Till startsidan';
   home.onclick = () => {
+    if (store.unsubscribe) { store.unsubscribe(); store.unsubscribe = null; }
     const pa = store.game.playerAName || 'Spelare A';
     const pb = store.game.playerBName || 'Spelare B';
     store.game = { ...DEFAULT_GAME, playerAName: pa, playerBName: pb };
-    encodeStateToURL(store.game);
+    store.gameId = '';
+    store.myRole = null;
+    setGameIdInURL('');
     navigate('home');
   };
 

--- a/src/screens/wait.js
+++ b/src/screens/wait.js
@@ -1,9 +1,8 @@
 import { store } from '../store.js';
-import { navigate } from '../router.js';
-import { encodeStateToURL } from '../urlState.js';
 import { updateScoreBar, setScreen, screens } from '../ui.js';
 import { stopCamera } from '../camera.js';
 import { translateLabelToSv } from '../translations.js';
+import { updateGame } from '../firebase.js';
 
 export function renderWait() {
   updateScoreBar();
@@ -11,42 +10,97 @@ export function renderWait() {
   stopCamera();
   screens.wait.innerHTML = '';
 
+  const { game, gameId, myRole } = store;
   const c = document.createElement('div');
   c.className = 'center card';
 
-  const info = document.createElement('div');
-  info.innerHTML = `<div>Delad utmaning: <span class="name">${(store.game.targetLabel || '-').toUpperCase()}</span></div>`;
-  translateLabelToSv(store.game.targetLabel).then(sv => {
-    const span = info.querySelector('.name');
-    if (span && sv) span.textContent = (sv || '').toUpperCase();
-  }).catch(() => {});
+  if (game.status === 'inviting' && myRole === 'A') {
+    // Player A waiting for Player B to open the invite link and accept
+    const h = document.createElement('h2');
+    h.textContent = 'Inbjudan skickad!';
+    c.appendChild(h);
 
-  const tip = document.createElement('div');
-  tip.className = 'hint';
-  tip.textContent = 'Väntar på motspelaren. Dela länken om du inte gjort det.';
+    const msg = document.createElement('div');
+    msg.textContent = `Väntar på att ${game.playerBName} accepterar inbjudan...`;
+    c.appendChild(msg);
 
-  const back = document.createElement('button');
-  back.className = 'ghost';
-  back.textContent = 'Till startsidan';
-  back.onclick = () => navigate('home');
+    const tip = document.createElement('div');
+    tip.className = 'hint';
+    tip.textContent = 'Håll den här skärmen öppen. Du får ett meddelande när motspelaren accepterar.';
+    c.appendChild(tip);
 
-  try {
-    if (store.game.gameId && localStorage.getItem('itta_owner_gid') === store.game.gameId) {
-      const cancel = document.createElement('button');
-      cancel.className = 'danger';
-      cancel.textContent = 'Avbryt spel';
-      cancel.onclick = () => {
-        store.game.isActive = false;
-        store.game.canceledBy = store.game.playerAName || 'Spelare A';
-        encodeStateToURL(store.game);
-        navigate('cancel');
-      };
-      c.appendChild(cancel);
-    }
-  } catch {}
+    c.appendChild(makeCancelBtn(game, gameId, myRole));
 
-  c.appendChild(info);
-  c.appendChild(tip);
-  c.appendChild(back);
+  } else if (game.status === 'accepted' && myRole === 'A') {
+    // Player B accepted — Player A can now start the game
+    const h = document.createElement('h2');
+    h.textContent = `${game.playerBName} är redo!`;
+    c.appendChild(h);
+
+    const startBtn = document.createElement('button');
+    startBtn.className = 'primary';
+    startBtn.textContent = 'Starta spelet!';
+    startBtn.onclick = async () => {
+      startBtn.disabled = true;
+      await updateGame(gameId, { status: 'playing' });
+      // Firebase listener navigates both players to their screens
+    };
+    c.appendChild(startBtn);
+    c.appendChild(makeCancelBtn(game, gameId, myRole));
+
+  } else if (game.status === 'accepted' && myRole === 'B') {
+    // Player B waiting for Player A to start
+    const h = document.createElement('h2');
+    h.textContent = 'Inbjudan accepterad!';
+    c.appendChild(h);
+
+    const msg = document.createElement('div');
+    msg.textContent = `Väntar på att ${game.playerAName} startar spelet...`;
+    c.appendChild(msg);
+
+  } else if (game.status === 'playing' && game.targetLabel) {
+    // Challenger is waiting for finder to find the object
+    const h = document.createElement('h2');
+    h.textContent = 'Väntar på motspelaren...';
+    c.appendChild(h);
+
+    const info = document.createElement('div');
+    const nameSpan = document.createElement('span');
+    nameSpan.className = 'name';
+    nameSpan.textContent = game.targetLabel.toUpperCase();
+    info.append('Utmaningen: ', nameSpan);
+    translateLabelToSv(game.targetLabel).then(sv => {
+      if (sv) nameSpan.textContent = sv.toUpperCase();
+    }).catch(() => {});
+    c.appendChild(info);
+
+    c.appendChild(makeCancelBtn(game, gameId, myRole));
+
+  } else if (game.status === 'playing' && !game.targetLabel) {
+    // Finder is waiting for challenger to pick an object
+    const challName = game.currentTurn === 'A' ? game.playerAName : game.playerBName;
+    const h = document.createElement('h2');
+    h.textContent = 'Väntar på utmaning...';
+    c.appendChild(h);
+
+    const msg = document.createElement('div');
+    msg.textContent = `${challName} väljer ett objekt att utmana dig med.`;
+    c.appendChild(msg);
+  }
+
   screens.wait.appendChild(c);
+}
+
+function makeCancelBtn(game, gameId, myRole) {
+  const btn = document.createElement('button');
+  btn.className = 'danger';
+  btn.textContent = 'Avbryt spel';
+  btn.style.marginTop = '1rem';
+  btn.onclick = async () => {
+    btn.disabled = true;
+    const canceledBy = myRole === 'A' ? game.playerAName : game.playerBName;
+    await updateGame(gameId, { status: 'canceled', canceledBy });
+    // Firebase listener navigates both players to cancel screen
+  };
+  return btn;
 }

--- a/src/screens/win.js
+++ b/src/screens/win.js
@@ -1,6 +1,6 @@
 import { store } from '../store.js';
 import { navigate } from '../router.js';
-import { encodeStateToURL } from '../urlState.js';
+import { setGameIdInURL } from '../urlState.js';
 import { updateScoreBar, setScreen, screens } from '../ui.js';
 import { DEFAULT_GAME } from '../constants.js';
 
@@ -16,18 +16,27 @@ export function renderWin() {
   const msg = document.createElement('h2');
   msg.textContent = `${who} vann!`;
 
+  const score = document.createElement('div');
+  score.className = 'hint';
+  score.textContent = `${store.game.playerAName} ${store.game.playerAScore} – ${store.game.playerBScore} ${store.game.playerBName}`;
+
   const again = document.createElement('button');
   again.className = 'primary';
   again.textContent = 'Spela igen';
   again.onclick = () => {
+    // Detach Firebase listener and clear game state to start fresh
+    if (store.unsubscribe) { store.unsubscribe(); store.unsubscribe = null; }
     const pa = store.game.playerAName || 'Spelare A';
     const pb = store.game.playerBName || 'Spelare B';
     store.game = { ...DEFAULT_GAME, playerAName: pa, playerBName: pb };
-    encodeStateToURL(store.game);
+    store.gameId = '';
+    store.myRole = null;
+    setGameIdInURL('');
     navigate('home');
   };
 
   c.appendChild(msg);
+  c.appendChild(score);
   c.appendChild(again);
   screens.win.appendChild(c);
 }

--- a/src/store.js
+++ b/src/store.js
@@ -2,4 +2,7 @@ import { DEFAULT_GAME } from './constants.js';
 
 export const store = {
   game: { ...DEFAULT_GAME },
+  gameId: '',        // Current game ID (from URL)
+  myRole: null,      // 'A' | 'B' | null — stored in localStorage per gameId
+  unsubscribe: null, // Function to detach the Firebase listener
 };

--- a/src/ui.js
+++ b/src/ui.js
@@ -22,7 +22,8 @@ export function setScreen(name) {
 export function updateScoreBar() {
   const aName = store.game.playerAName || 'Spelare A';
   const bName = store.game.playerBName || 'Spelare B';
-  const active = store.game.isActive ? (store.game.currentTurn === 'A' ? 'B' : 'A') : '';
+  const isPlaying = store.game.status === 'playing' || store.game.isActive;
+  const active = isPlaying ? (store.game.currentTurn === 'A' ? 'B' : 'A') : '';
   const aClass = active === 'A' ? 'badge active' : 'badge';
   const bClass = active === 'B' ? 'badge active' : 'badge';
   scoreBar.innerHTML = `
@@ -44,7 +45,7 @@ export async function shareLink(text) {
   const url = location.href;
   const full = `${text} ${url}`.trim();
   if (navigator.share) {
-    navigator.share({ title: 'itta! utmaning', text, url }).catch(() => {});
+    navigator.share({ title: 'Hitta! – Inbjudan', text, url }).catch(() => {});
     return;
   }
   const sms = `sms:?&body=${encodeURIComponent(full)}`;

--- a/src/urlState.js
+++ b/src/urlState.js
@@ -1,39 +1,13 @@
-import { DEFAULT_GAME, WIN_POINTS } from './constants.js';
+// URL state is now minimal — only the game ID is stored in the URL.
+// All other game state lives in Firebase Realtime Database.
 
-export function encodeStateToURL(next) {
-  const url = new URL(location.href);
-  const params = url.searchParams;
-  params.set('pa', next.playerAName || '');
-  params.set('pb', next.playerBName || '');
-  params.set('sa', String(next.playerAScore || 0));
-  params.set('sb', String(next.playerBScore || 0));
-  params.set('t', next.currentTurn || 'A');
-  params.set('lbl', next.targetLabel || '');
-  params.set('cf', String(next.targetConfidence || 0));
-  params.set('act', next.isActive ? '1' : '0');
-  params.set('w', next.winner || '');
-  params.set('wp', String(next.winPoints || WIN_POINTS));
-  params.set('cx', next.canceledBy || '');
-  params.set('gid', next.gameId || '');
-  history.replaceState({}, '', url);
+export function getGameIdFromURL() {
+  return new URL(location.href).searchParams.get('gid') || '';
 }
 
-export function decodeStateFromURL() {
+export function setGameIdInURL(gameId) {
   const url = new URL(location.href);
-  const p = url.searchParams;
-  return {
-    ...DEFAULT_GAME,
-    playerAName: p.get('pa') || '',
-    playerBName: p.get('pb') || '',
-    playerAScore: parseInt(p.get('sa') || '0', 10) || 0,
-    playerBScore: parseInt(p.get('sb') || '0', 10) || 0,
-    currentTurn: (p.get('t') || 'A') === 'B' ? 'B' : 'A',
-    targetLabel: p.get('lbl') || '',
-    targetConfidence: parseFloat(p.get('cf') || '0') || 0,
-    isActive: p.get('act') === '1',
-    winner: p.get('w') || '',
-    winPoints: parseInt(p.get('wp') || String(WIN_POINTS), 10) || WIN_POINTS,
-    canceledBy: p.get('cx') || '',
-    gameId: p.get('gid') || '',
-  };
+  url.search = '';
+  if (gameId) url.searchParams.set('gid', gameId);
+  history.replaceState({}, '', url);
 }


### PR DESCRIPTION
- Renamed game from "itta!" to "Hitta!" throughout (title, brand, share text)
- Added Firebase Realtime Database for all game communication:
  - Player A sends invite via native share/SMS — link contains only game ID
  - Player B opens link, enters name and accepts via Firebase (no refresh needed)
  - Player A sees acceptance in real-time and can start the game
  - All gameplay (target chosen, round result, scores, win, cancel) synced via Firebase onValue listener — the screen never needs a manual refresh
- Game state is now stored in Firebase instead of URL parameters; URL holds only the game ID (?gid=...)
- Player roles (A/B) stored in localStorage per game ID
- New database.rules.json with open read/write rules for game nodes
- src/firebase-config.js added with placeholders — fill in before deploying

https://claude.ai/code/session_015y38NFt6U2hisBfLEcwaQ9