### PR TITLE
Fix challenge refresh, improve challenge label and countdown visibility

### DIFF
--- a/src/screens/detect.js
+++ b/src/screens/detect.js
@@ -5,6 +5,7 @@ import { loadModel, detectObjects, getModel } from '../detector.js';
 import { translateLabelToSv } from '../translations.js';
 import { MIN_SCORE } from '../constants.js';
 import { updateGame } from '../firebase.js';
+import { navigate } from '../router.js';
 
 function buildBox(x, y, w, h, scaleX, scaleY, label, confidence) {
   const b = document.createElement('div');
@@ -128,8 +129,9 @@ export function renderDetect() {
   async function pickTarget(p) {
     const targetLabel = p.label || p.class || '';
     const targetConfidence = p.confidence || p.score || 0;
-    // Write chosen target to Firebase — the listener on both devices handles navigation
     await updateGame(store.gameId, { targetLabel, targetConfidence });
+    // Navigate immediately — don't wait for the next subscription poll cycle
+    navigate('wait');
   }
 
   startCamera(video).then(loadModel).then(() => {

--- a/src/screens/home.js
+++ b/src/screens/home.js
@@ -196,8 +196,10 @@ async function renderAcceptInvite() {
     const playerBName = nameInput.value.trim() || 'Spelare B';
     try { localStorage.setItem(`hitta_role_${store.gameId}`, 'B'); } catch {}
     store.myRole = 'B';
+    // Optimistic update so wait screen renders correctly without waiting for poll
+    store.game = { ...store.game, playerBName, status: 'accepted' };
     await updateGame(store.gameId, { playerBName, status: 'accepted' });
-    // Firebase listener (already set up in route()) will navigate to 'wait'
+    navigate('wait');
   };
   wrap.appendChild(acceptBtn);
   screens.home.appendChild(wrap);

--- a/src/screens/play.js
+++ b/src/screens/play.js
@@ -30,8 +30,8 @@ export function renderPlay() {
   container.className = 'col';
 
   const pill = document.createElement('div');
-  pill.className = 'pill';
-  pill.innerHTML = `<span>Hitta: <span class="name">${(store.game.targetLabel || '').toUpperCase()}</span></span>`;
+  pill.className = 'challenge-pill';
+  pill.innerHTML = `Hitta: <span class="name">${(store.game.targetLabel || '').toUpperCase()}</span>`;
   translateLabelToSv(store.game.targetLabel).then(sv => {
     const span = pill.querySelector('.name');
     if (span && sv) span.textContent = (sv || '').toUpperCase();
@@ -56,7 +56,7 @@ export function renderPlay() {
   const actions = document.createElement('div');
   actions.className = 'footer-actions';
   const timerEl = document.createElement('div');
-  timerEl.className = 'pill timer';
+  timerEl.className = 'timer-display';
   timerEl.id = 'play-timer';
   timerEl.textContent = formatTime(TURN_SECONDS);
   const snap = document.createElement('button');

--- a/styles.css
+++ b/styles.css
@@ -41,6 +41,9 @@ video, canvas{width:100%;height:auto;display:block}
 .center{display:flex;flex-direction:column;align-items:center;justify-content:center;gap:16px;text-align:center;margin-top:10vh}
 .pill{display:inline-flex;gap:8px;align-items:center;border:1px solid var(--border);border-radius:999px;padding:6px 10px;color:var(--muted);font-size:12px}
 .name{font-weight:700}
+.challenge-pill{display:flex;align-items:center;justify-content:center;gap:8px;border:2px solid var(--accent);border-radius:999px;padding:10px 20px;font-size:14px;background:rgba(54,211,153,0.08);font-weight:600;color:var(--fg)}
+.challenge-pill .name{font-size:24px;font-weight:900;color:var(--accent);letter-spacing:1px}
+.timer-display{font-variant-numeric:tabular-nums;font-weight:900;font-size:22px;border:2px solid var(--accent);border-radius:999px;padding:8px 16px;min-width:80px;text-align:center;background:rgba(54,211,153,0.1);color:var(--accent)}
 .grid{display:grid;grid-template-columns:1fr 1fr;gap:10px}
 
 .notice{background:#1b1b1b;border:1px solid var(--border);padding:12px 14px;border-radius:10px}


### PR DESCRIPTION
- detect.js: navigate to wait screen immediately after pickTarget succeeds,
  instead of waiting up to 1.5s for the next subscription poll cycle. This
  ensures the challenger's screen transitions instantly and the opponent's
  wait→play navigation is reliable.
- play.js: replace small muted pill with prominent challenge-pill showing
  the target object name in large accent text
- play.js: replace small pill timer with larger timer-display element
- styles.css: add .challenge-pill (accented border, large object name) and
  .timer-display (big, accent-colored, tabular numerals) classes

https://claude.ai/code/session_01GmTJKPDHGivykxCjBbvwad