### PR TITLE
Fix frontend freeze when camera/model fails on play or detect screen

### DIFF
--- a/src/screens/detect.js
+++ b/src/screens/detect.js
@@ -143,8 +143,18 @@ export function renderDetect() {
     });
   }).catch(err => {
     console.error('Kamerastart fel:', err);
-    alert(err.message || 'Kunde inte starta kamera. Ge kameratillstånd och försök igen.');
-    setScreen('home');
+    screens.detect.innerHTML = '';
+    const errWrap = document.createElement('div');
+    errWrap.className = 'center card';
+    const errMsg = document.createElement('p');
+    errMsg.textContent = err.message || 'Kunde inte starta kamera. Ge kameratillstånd och försök igen.';
+    const retryBtn = document.createElement('button');
+    retryBtn.className = 'primary';
+    retryBtn.textContent = 'Försök igen';
+    retryBtn.onclick = () => renderDetect();
+    errWrap.appendChild(errMsg);
+    errWrap.appendChild(retryBtn);
+    screens.detect.appendChild(errWrap);
   });
 
   snap.onclick = async () => {

--- a/src/screens/play.js
+++ b/src/screens/play.js
@@ -185,8 +185,18 @@ export function renderPlay() {
     });
   }).catch(err => {
     console.error('Kamerastart fel:', err);
-    alert(err.message || 'Kunde inte starta kamera. Ge kameratillstånd och försök igen.');
-    setScreen('home');
+    screens.play.innerHTML = '';
+    const errWrap = document.createElement('div');
+    errWrap.className = 'center card';
+    const errMsg = document.createElement('p');
+    errMsg.textContent = err.message || 'Kunde inte starta kamera. Ge kameratillstånd och försök igen.';
+    const retryBtn = document.createElement('button');
+    retryBtn.className = 'primary';
+    retryBtn.textContent = 'Försök igen';
+    retryBtn.onclick = () => renderPlay();
+    errWrap.appendChild(errMsg);
+    errWrap.appendChild(retryBtn);
+    screens.play.appendChild(errWrap);
   });
 
   giveUp.onclick = () => finishRound(false);


### PR DESCRIPTION
setScreen('home') in the error handlers would show the home screen
with stale DOM (including the old "Accepterar..." accept button) while
currentScreen remained 'play'/'detect'. The router then saw
targetScreen === currentScreen and never navigated, causing a permanent
freeze.

Replace the setScreen('home') fallback with an inline error message and
retry button on the current screen, keeping currentScreen consistent
with what is actually displayed.

https://claude.ai/code/session_01N3ETxjiVzFUfUpzmBtthDn