### PR TITLE
Fix turn-switch flip-flop via revision guard and upgrade detection model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ There is no build step, linter, or test suite configured. The app is served dire
 - **store.js** — Thin global reactive store holding `gameState` and `userRole`
 - **constants.js** — `WIN_POINTS`, `TURN_SECONDS` (120), `MIN_SCORE` (0.6)
 - **camera.js** — Wraps `getUserMedia`, manages live detection loop
-- **detector.js** — Loads YOLO/COCO-SSD model from CDN, runs object detection, returns labeled bounding boxes
+- **detector.js** — Loads COCO-SSD (mobilenet_v2 base) via TensorFlow.js, runs object detection, returns labeled bounding boxes
 - **firebase.js** — Backend abstraction: GET/POST/PATCH game state via `/api/game` Netlify Function (despite the name, this is **not Firebase**)
 - **translations.js** — Translates English ML labels to Swedish (cached, with LibreTranslate fallback)
 - **timer.js** — Manages 120-second turn countdown
@@ -49,7 +49,7 @@ Real-time sync is achieved by polling every 1500ms from the client.
 
 ### Key Design Decisions
 
-- All ML inference runs **client-side** (TensorFlow.js + ML5.js loaded from CDN in `index.html`)
+- All ML inference runs **client-side** (TensorFlow.js + COCO-SSD loaded from CDN in `index.html`; model weights are downloaded once and cached, inference never leaves the device)
 - No build tooling; ES modules served directly from root
 - State lives in Netlify Blobs (keyed by `gameId`); no auth or user accounts
 - UI language is Swedish; object detection labels translated on the fly

--- a/index.html
+++ b/index.html
@@ -5,7 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <title>Hitta! – Objektduellen</title>
   <link rel="preconnect" href="https://cdn.jsdelivr.net">
-  <link rel="preconnect" href="https://unpkg.com">
   <link rel="stylesheet" href="./styles.css">
   <meta name="theme-color" content="#111">
   <meta name="apple-mobile-web-app-capable" content="yes">
@@ -27,9 +26,8 @@
   </main>
 
   <script src="https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@4.20.0/dist/tf.min.js" crossorigin="anonymous"></script>
-  <script src="https://unpkg.com/ml5@0.21.0/dist/ml5.min.js" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/@tensorflow-models/coco-ssd@2.2.3/dist/coco-ssd.min.js" crossorigin="anonymous"></script>
-  <script type="module" src="./src/main.js?v=2"></script>
+  <script type="module" src="./src/main.js?v=3"></script>
 </body>
 </html>
 

--- a/netlify/functions/game.js
+++ b/netlify/functions/game.js
@@ -32,7 +32,9 @@ export default async (req) => {
 
   if (!gameId) return json({ error: "Missing game id" }, 400);
 
-  const store = getStore("games");
+  // Strong consistency: polling clients must never read a stale replica after
+  // a turn switch, or screens flip-flop between old and new game state.
+  const store = getStore({ name: "games", consistency: "strong" });
 
   if (req.method === "GET") {
     const data = await store.get(gameId, { type: "json" });
@@ -41,7 +43,7 @@ export default async (req) => {
 
   if (req.method === "POST") {
     const body = await req.json();
-    await store.setJSON(gameId, body);
+    await store.setJSON(gameId, { ...body, rev: 1 });
     return json({ ok: true });
   }
 
@@ -57,7 +59,8 @@ export default async (req) => {
         delete updates.status;
       }
     }
-    const merged = { ...existing, ...updates };
+    // Monotonic revision lets clients discard stale poll responses.
+    const merged = { ...existing, ...updates, rev: (existing.rev || 0) + 1 };
     await store.setJSON(gameId, merged);
     return json({ ok: true });
   }

--- a/src/detector.js
+++ b/src/detector.js
@@ -1,6 +1,10 @@
-import { MIN_SCORE } from './constants.js';
-
-let yoloModel = null;
+// Object detection runs fully in the browser via TensorFlow.js COCO-SSD.
+// The 'mobilenet_v2' base (SSDLite MobileNetV2) is noticeably more accurate
+// than the default 'lite_mobilenet_v2' while still running in real time on
+// mobile. The model is downloaded once and cached by the browser; inference
+// never leaves the device.
+let model = null;
+let modelPromise = null;
 
 function waitForScripts() {
   return new Promise((resolve, reject) => {
@@ -8,8 +12,7 @@ function waitForScripts() {
     const maxAttempts = 50;
     const check = () => {
       attempts++;
-      if (typeof ml5 !== 'undefined' || typeof cocoSsd !== 'undefined') {
-        console.log('Skript laddade efter', attempts * 100, 'ms');
+      if (typeof cocoSsd !== 'undefined') {
         resolve();
       } else if (attempts >= maxAttempts) {
         reject(new Error('Skript laddades inte inom 5 sekunder. Kontrollera din internetanslutning.'));
@@ -22,56 +25,30 @@ function waitForScripts() {
 }
 
 export async function loadModel() {
-  if (yoloModel) return yoloModel;
-
-  console.log('Försöker ladda objektigenkänningsmodell...');
-  await waitForScripts();
-
-  if (typeof ml5 !== 'undefined' && ml5.objectDetector) {
-    try {
-      console.log('Laddar YOLO-modell...');
-      yoloModel = await ml5.objectDetector('YOLO', {
-        filterBoxesThreshold: 0.01,
-        IOUThreshold: 0.4,
-        classProbThreshold: MIN_SCORE,
-      });
-      console.log('YOLO-modell laddad framgångsrikt');
-      return yoloModel;
-    } catch (error) {
-      console.warn('YOLO-modell misslyckades, försöker COCO-SSD:', error);
-    }
-  } else {
-    console.warn('ml5.js inte tillgängligt, försöker COCO-SSD');
+  if (!modelPromise) {
+    modelPromise = (async () => {
+      console.log('Laddar COCO-SSD (mobilenet_v2)...');
+      await waitForScripts();
+      const m = await cocoSsd.load({ base: 'mobilenet_v2' });
+      console.log('Objektigenkänningsmodell laddad');
+      model = m;
+      return m;
+    })().catch((err) => {
+      console.error('Modelladdning misslyckades:', err);
+      // Allow a retry on the next call instead of caching the failure forever.
+      modelPromise = null;
+      throw new Error('Kunde inte ladda objektigenkänningsmodellen. Kontrollera din internetanslutning och försök igen.');
+    });
   }
-
-  if (typeof cocoSsd !== 'undefined') {
-    try {
-      console.log('Laddar COCO-SSD-modell som fallback...');
-      yoloModel = await cocoSsd.load({ base: 'lite_mobilenet_v2' });
-      console.log('COCO-SSD-modell laddad framgångsrikt');
-      return yoloModel;
-    } catch (error) {
-      console.error('COCO-SSD-modell misslyckades:', error);
-    }
-  }
-
-  throw new Error('Kunde inte ladda någon objektigenkänningsmodell. Kontrollera din internetanslutning och ladda om sidan.');
+  return modelPromise;
 }
 
 export async function detectObjects(model, input) {
-  if (model.detect && typeof model.detect === 'function' && model.detect.length === 2) {
-    return new Promise((resolve, reject) => {
-      model.detect(input, (err, results) => {
-        if (err) reject(err);
-        else resolve(results || []);
-      });
-    });
-  }
   return model.detect(input);
 }
 
 export function getModel() {
-  return yoloModel;
+  return model;
 }
 
 export function parseBbox(p) {

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -33,15 +33,26 @@ export async function getGame(gameId) {
 export function subscribeGame(gameId, callback) {
   let active = true;
   let prev = '';
+  let lastRev = 0;
 
   async function poll() {
     while (active) {
       try {
         const data = await getGame(gameId);
-        const json = JSON.stringify(data);
-        if (json !== prev) {
-          prev = json;
-          callback(data);
+        // Discard stale reads: the server bumps `rev` on every write, so a
+        // response with a lower rev than one we've already seen is old state
+        // (e.g. a lagging replica right after a turn switch) — acting on it
+        // would route players back to the previous round's screens.
+        const rev = data ? (data.rev || 0) : 0;
+        if (data && rev < lastRev) {
+          // skip
+        } else {
+          const json = JSON.stringify(data);
+          if (json !== prev) {
+            prev = json;
+            lastRev = rev;
+            callback(data);
+          }
         }
       } catch {
         // ignore transient errors, keep polling

--- a/src/screens/detect.js
+++ b/src/screens/detect.js
@@ -103,7 +103,17 @@ export function renderDetect() {
   };
 
   async function pickTarget(p) {
-    await updateGame(store.gameId, { targetLabel: getLabel(p), targetConfidence: getScore(p) });
+    const updates = { targetLabel: getLabel(p), targetConfidence: getScore(p) };
+    try {
+      await updateGame(store.gameId, updates);
+    } catch (err) {
+      console.error('Kunde inte skicka utmaningen:', err);
+      alert('Kunde inte skicka utmaningen. Kontrollera din anslutning och välj objektet igen.');
+      return;
+    }
+    // Optimistic local update so the wait screen shows the chosen challenge
+    // immediately instead of after the next poll.
+    store.game = { ...store.game, ...updates };
     navigate('wait');
   }
 

--- a/src/screens/play.js
+++ b/src/screens/play.js
@@ -21,6 +21,7 @@ export function renderPlay() {
   screens.play.innerHTML = '';
 
   let roundAwarded = false;
+  let pendingUpdates = null; // set when a finished round failed to save, so a retry reuses the same result
 
   const container = document.createElement('div');
   container.className = 'col';
@@ -91,28 +92,56 @@ export function renderPlay() {
     stopCamera();
     stopLiveDetect();
 
-    let { playerAScore, playerBScore, currentTurn, winPoints } = store.game;
-    winPoints = winPoints || WIN_POINTS;
+    let updates = pendingUpdates;
+    if (!updates) {
+      let { playerAScore, playerBScore, currentTurn, winPoints } = store.game;
+      winPoints = winPoints || WIN_POINTS;
 
-    if (success) {
-      // Finder scores: when turn='A' (A challenges), B is the finder
-      if (currentTurn === 'A') playerBScore += 1;
-      else playerAScore += 1;
-      showFeedbackPlusOne();
+      if (success) {
+        // Finder scores: when turn='A' (A challenges), B is the finder
+        if (currentTurn === 'A') playerBScore += 1;
+        else playerAScore += 1;
+        showFeedbackPlusOne();
+      }
+
+      const newTurn = currentTurn === 'A' ? 'B' : 'A';
+      const winner = computeWinner(playerAScore, playerBScore, winPoints);
+
+      updates = {
+        playerAScore,
+        playerBScore,
+        currentTurn: newTurn,
+        targetLabel: '',
+        targetConfidence: 0,
+        status: winner ? 'won' : 'playing',
+        winner,
+      };
     }
 
-    const newTurn = currentTurn === 'A' ? 'B' : 'A';
-    const winner = computeWinner(playerAScore, playerBScore, winPoints);
+    // Persist the round result with retries — losing this write would leave
+    // the other player waiting forever on the previous round.
+    let saved = false;
+    for (let attempt = 0; attempt < 3 && !saved; attempt++) {
+      try {
+        await updateGame(store.gameId, updates);
+        saved = true;
+      } catch (err) {
+        console.error(`Kunde inte spara rundan (försök ${attempt + 1}):`, err);
+        if (attempt < 2) await new Promise(r => setTimeout(r, 1000 * (attempt + 1)));
+      }
+    }
+    if (!saved) {
+      roundAwarded = false;
+      pendingUpdates = updates;
+      alert('Kunde inte spara rundan. Kontrollera din anslutning och tryck "Ge upp" för att försöka igen.');
+      return;
+    }
+    pendingUpdates = null;
 
-    await updateGame(store.gameId, {
-      playerAScore,
-      playerBScore,
-      currentTurn: newTurn,
-      targetLabel: '',
-      targetConfidence: 0,
-      status: winner ? 'won' : 'playing',
-      winner,
-    });
+    // Optimistic local update so the score bar and next screen are correct
+    // immediately instead of after the next poll.
+    const { winner } = updates;
+    store.game = { ...store.game, ...updates };
 
     // Navigate immediately — the finder always becomes the next challenger.
     // The other player's subscription handles their side within POLL_MS.


### PR DESCRIPTION
Turn-switch bug: Netlify Blobs reads are eventually consistent by
default, and the client polling loop only deduplicated on raw JSON.
Right after a round ended, a lagging replica could return the previous
round's state, which the client treated as fresh: the old challenger got
pulled back into the play screen with the stale target, the new
challenger was bounced off the detect screen, and a stale-scored
finishRound could re-award points.

- game.js: open the blob store with strong consistency and stamp a
  monotonic rev on every write (POST rev=1, PATCH rev+1)
- firebase.js: discard poll responses whose rev is lower than the
  newest already seen
- play.js: retry saving the round result with backoff (reusing the same
  computed result on retry), and update the local store optimistically
  so the score bar and next screen are correct before the next poll
- detect.js: handle pickTarget failure with a user-facing message and
  set targetLabel locally so the wait screen shows the challenge
  immediately

Detection model: the ml5@0.21.0 script tag pointed at a version that
does not exist on npm, so ml5 never loaded and the app always silently
fell back to COCO-SSD lite_mobilenet_v2, the least accurate variant.
Remove the dead ml5/tiny-YOLO path and load COCO-SSD with the
mobilenet_v2 base (highest-accuracy variant), still fully in-browser.
detector.js now shares a single load promise so concurrent loadModel
calls cannot download the model twice, and a failed load can be retried.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0191399EJAKL6dSAeebMHJFn